### PR TITLE
Retain type hints when constructing a composed function

### DIFF
--- a/src/compose.php
+++ b/src/compose.php
@@ -16,6 +16,11 @@ function compose() {
     }
 
     $fns = func_get_args();
+    $f = new \ReflectionFunction($fns[count($fns)-1]);
+    $args = implode(',', array_map(function ($p) {
+        return (($c = $p->getClass()) ? '\\'.$c->getName() : '').' $'.$p->getName();
+    }, $f->getParameters()));
+
     $prev = array_shift($fns);
 
     foreach ($fns as $fn) {
@@ -23,6 +28,8 @@ function compose() {
             $args = func_get_args();
             return $prev(compose\apply($fn, $args));
         };
+        $fnSrc = 'return function ('.$args.') use ($prev) { return call_user_func_array($prev, func_get_args());};';
+        $prev = eval($fnSrc);
     }
 
     return $prev;

--- a/tests/ComposeTest.php
+++ b/tests/ComposeTest.php
@@ -59,4 +59,19 @@ class ComposeTest extends \PHPUnit_Framework_TestCase {
         );
         $this->assertSame('baz(bar(foo(x)))', $composed('x'));
     }
+
+    function testComposeReflectTypeHints() {
+        $composed = compose(
+            function (Foo $x) { return $x; },
+            function (Foo $x, Bar $y) { return $x; }
+        );
+
+        $f = new \ReflectionFunction($composed);
+
+        $this->assertEquals('igorw\Foo', $f->getParameters()[0]->getClass()->getName());
+        $this->assertEquals('igorw\Bar', $f->getParameters()[1]->getClass()->getName());
+    }
 }
+
+class Foo {};
+class Bar {};


### PR DESCRIPTION
This is useful if code you are passing a composed function to inspects the function with reflection to determine which parameters to pass to the function.

An example would be the controller resolver in the Symfony HttpKernel through which Silex tries to inject the Application or the Request object if a type hint exists. So with this patch it becomes possible to use composed functions as callbacks for Silex routes.

Long live eval.
